### PR TITLE
Fix incorrect casing of header filename.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,5 @@
 #include <QGuiApplication>
-#include <qqmlapplicationengine>
+#include <QQmlApplicationEngine>
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Fixes https://github.com/mattfife/QtQuick-with-cmake/issues/2.